### PR TITLE
Switch to mavenCentral from Jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ import groovyx.net.http.Method
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url = "http://files.minecraftforge.net/maven" }
         maven { url "https://plugins.gradle.org/m2/" }
     }


### PR DESCRIPTION
Switch to mavenCentral from JCenter. Tested by switching, cleaning cache, and rerunning setupDecompWorkspace, for which everything worked.