### PR TITLE
Invalidate cache itemstack and state after failed recipe completion

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/tile/TileCompressor.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/tile/TileCompressor.java
@@ -61,7 +61,7 @@ public class TileCompressor
 		boolean mark = false;
 
 		if (!this.getWorld().isRemote) {
-			CompressorRecipe recipe = this.getRecipe();
+			CompressorRecipe recipe = null;
 			ItemStack output = this.getStackInSlot(0);
 			ItemStack input = this.getStackInSlot(1);
 
@@ -69,6 +69,8 @@ public class TileCompressor
 				if (this.materialStack.isEmpty()) {
 					this.materialStack = input.copy();
 					mark = true;
+					//Retrieve new recipe upon non-null item detected
+					recipe = getRecipe();
 				}
 
 				if (!this.inputLimit || (recipe != null && this.materialCount < recipe.getInputCount())) {
@@ -82,6 +84,11 @@ public class TileCompressor
 						this.materialCount += consumeAmount;
 						mark = true;
 					}
+				}
+				//Invalidate the cached item and marked state on unsuccessful recipe retrieval
+				else if(mark) {
+					this.materialStack = ItemStack.EMPTY;
+					mark = false;
 				}
 			}
 


### PR DESCRIPTION
A couple changes related to #7 

First, delay the recipe lookup until after there is confirmed to be a non-null item. Previously the recipe lookup would run before a guaranteed item was found, which means that `recipe` would always be null, even if the input check found an applicable item.

This change defers the recipe lookup to after finding an item, so that `recipe` will not be null (for an input item) after the new input item is set.

Secondly, if the input consumption failed due to null recipe or other factor, reset the cached itemstack and the mark state. This part is what addresses the issue in #7.

Fixes #7